### PR TITLE
Add ARM64 platform support to Docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,6 +72,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- Adds `platforms: linux/amd64,linux/arm64` to the `build-push-action` step in the Docker workflow
- Fixes Raspberry Pi (ARM64) users getting "no matching manifest" errors when pulling the image
- No Dockerfile changes needed — `node:20-alpine` already has multi-arch support and Buildx is already configured

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)