### PR TITLE
Add source-aware icons for media player and Input sensor, fix Spotify/Radio detection for soundbars

### DIFF
--- a/custom_components/teufel_raumfeld_raumkernel/manifest.json
+++ b/custom_components/teufel_raumfeld_raumkernel/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ulilicht/ha-raumkernel/issues",
   "requirements": [],
-  "version": "1.2.14"
+  "version": "1.2.15"
 }

--- a/custom_components/teufel_raumfeld_raumkernel/media_player.py
+++ b/custom_components/teufel_raumfeld_raumkernel/media_player.py
@@ -151,6 +151,19 @@ class RaumfeldMediaPlayer(MediaPlayerEntity):
         self._attr_media_image_url = now_playing.get("image")
         self._attr_media_content_id = now_playing.get("uri")
 
+        # When there's no album art (e.g. Line-in, Optical, TV), show an icon
+        # and the source name instead of a blank media player.
+        current_source = now_playing.get("currentSource", "Raumfeld")
+        source_icon = self._SOURCE_ICONS.get(current_source)
+        if not self._attr_media_image_url and source_icon:
+            self._attr_icon = source_icon
+            if not self._attr_media_title:
+                self._attr_media_title = self._SOURCE_RAW_TO_DISPLAY.get(
+                    current_source, current_source
+                )
+        else:
+            self._attr_icon = "mdi:speaker-multiple"
+
         # Store UPnP class for media_content_type property
         self._upnp_class = now_playing.get("classString", "")
 
@@ -255,6 +268,14 @@ class RaumfeldMediaPlayer(MediaPlayerEntity):
         "TV": "TV_ARC",
     }
     _SOURCE_RAW_TO_DISPLAY = {v: k for k, v in _SOURCE_DISPLAY_TO_RAW.items()}
+
+    # Icons shown in place of album art when no media image is available
+    # (e.g. external inputs without track metadata).
+    _SOURCE_ICONS = {
+        "LineIn": "mdi:audio-input-rca",
+        "OpticalIn": "mdi:toslink",
+        "TV_ARC": "mdi:hdmi-port",
+    }
 
     @property
     def source_list(self) -> list[str] | None:

--- a/custom_components/teufel_raumfeld_raumkernel/sensor.py
+++ b/custom_components/teufel_raumfeld_raumkernel/sensor.py
@@ -145,8 +145,18 @@ class RaumfeldPowerStatusSensor(RaumfeldSensorBase):
 class RaumfeldInputSensor(RaumfeldSensorBase):
     """Sensor showing the current input source."""
 
-    _attr_icon = "mdi:import"
     _attr_name = "Input"
+
+    # Icons for each raw "Source Select" / current source value.
+    _SOURCE_ICONS = {
+        "Raumfeld": "mdi:cast-audio",
+        "LineIn": "mdi:audio-input-rca",
+        "OpticalIn": "mdi:toslink",
+        "TV_ARC": "mdi:hdmi-port",
+        "Spotify": "mdi:spotify",
+        "Radio": "mdi:radio",
+    }
+    _DEFAULT_ICON = "mdi:import"
 
     def __init__(self, client: RaumfeldApiClient, room_data: dict[str, Any]) -> None:
         """Initialize."""
@@ -163,3 +173,4 @@ class RaumfeldInputSensor(RaumfeldSensorBase):
         self._attr_native_value = _SOURCE_RAW_TO_DISPLAY.get(
             current_source, current_source
         )
+        self._attr_icon = self._SOURCE_ICONS.get(current_source, self._DEFAULT_ICON)

--- a/ha-raumkernel-addon/CHANGELOG.md
+++ b/ha-raumkernel-addon/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.15
+
+- Show an icon and the source name in the media player when there's no album art (e.g. Line-in, Optical, TV): `mdi:audio-input-rca` for Line-in, `mdi:toslink` for Optical, `mdi:hdmi-port` for TV.
+- Add a dynamic icon to the "Input" sensor matching the current source: `mdi:cast-audio` for Streaming, `mdi:audio-input-rca` for Line-in, `mdi:toslink` for Optical, `mdi:hdmi-port` for TV, `mdi:spotify` for Spotify, `mdi:radio` for Radio.
+- Fix "Input" sensor for Soundbars/Sounddecks (devices with "Source Select"): now detects "Spotify"/"Radio" while streaming, instead of always showing "Streaming".
+
 ## 1.2.14
 
 - Add `selectSource` support for Soundbars and Sounddecks (TV_ARC, OpticalIn).

--- a/ha-raumkernel-addon/config.yaml
+++ b/ha-raumkernel-addon/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: "Raumkernel: Addon for Raumfeld devices"
-version: "1.2.14"
+version: "1.2.15"
 slug: ha-raumkernel-addon
 description: "Home Assistant Add-on for Teufel Raumfeld devices, providing a WebSocket API for the Raumfeld integration."
 url: "https://github.com/ulilicht/ha-raumkernel"

--- a/ha-raumkernel-addon/rootfs/app/RaumkernelHelper.js
+++ b/ha-raumkernel-addon/rootfs/app/RaumkernelHelper.js
@@ -669,7 +669,22 @@ class RaumkernelHelper {
      */
     _getCurrentSourceForRoom(room, uri, metadata = {}, physicalUri = '') {
         if (room?.sourceSwitchingSupported) {
-            return this._roomCurrentSourceCache.get(room.rendererUdn) || 'Raumfeld';
+            const sourceSelect = this._roomCurrentSourceCache.get(room.rendererUdn) || 'Raumfeld';
+
+            // "Source Select" only distinguishes physical inputs (LineIn, OpticalIn,
+            // TV_ARC) vs. "Raumfeld" (streaming). When streaming, inspect the URI to
+            // tell Spotify Connect/Radio apart from regular Raumfeld playback.
+            if (sourceSelect === 'Raumfeld') {
+                const lowerUri = uri.toLowerCase();
+                if (lowerUri.includes('spotifyconnect') || lowerUri.startsWith('spotify:')) {
+                    return 'Spotify';
+                }
+                if (lowerUri.includes('tunein')) {
+                    return 'Radio';
+                }
+            }
+
+            return sourceSelect;
         }
 
         const lowerUri = uri.toLowerCase();

--- a/ha-raumkernel-addon/teufel_raumfeld_raumkernel/manifest.json
+++ b/ha-raumkernel-addon/teufel_raumfeld_raumkernel/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ulilicht/ha-raumkernel/issues",
   "requirements": [],
-  "version": "1.2.14"
+  "version": "1.2.15"
 }

--- a/ha-raumkernel-addon/teufel_raumfeld_raumkernel/media_player.py
+++ b/ha-raumkernel-addon/teufel_raumfeld_raumkernel/media_player.py
@@ -151,6 +151,19 @@ class RaumfeldMediaPlayer(MediaPlayerEntity):
         self._attr_media_image_url = now_playing.get("image")
         self._attr_media_content_id = now_playing.get("uri")
 
+        # When there's no album art (e.g. Line-in, Optical, TV), show an icon
+        # and the source name instead of a blank media player.
+        current_source = now_playing.get("currentSource", "Raumfeld")
+        source_icon = self._SOURCE_ICONS.get(current_source)
+        if not self._attr_media_image_url and source_icon:
+            self._attr_icon = source_icon
+            if not self._attr_media_title:
+                self._attr_media_title = self._SOURCE_RAW_TO_DISPLAY.get(
+                    current_source, current_source
+                )
+        else:
+            self._attr_icon = "mdi:speaker-multiple"
+
         # Store UPnP class for media_content_type property
         self._upnp_class = now_playing.get("classString", "")
 
@@ -255,6 +268,14 @@ class RaumfeldMediaPlayer(MediaPlayerEntity):
         "TV": "TV_ARC",
     }
     _SOURCE_RAW_TO_DISPLAY = {v: k for k, v in _SOURCE_DISPLAY_TO_RAW.items()}
+
+    # Icons shown in place of album art when no media image is available
+    # (e.g. external inputs without track metadata).
+    _SOURCE_ICONS = {
+        "LineIn": "mdi:audio-input-rca",
+        "OpticalIn": "mdi:toslink",
+        "TV_ARC": "mdi:hdmi-port",
+    }
 
     @property
     def source_list(self) -> list[str] | None:

--- a/ha-raumkernel-addon/teufel_raumfeld_raumkernel/sensor.py
+++ b/ha-raumkernel-addon/teufel_raumfeld_raumkernel/sensor.py
@@ -145,8 +145,18 @@ class RaumfeldPowerStatusSensor(RaumfeldSensorBase):
 class RaumfeldInputSensor(RaumfeldSensorBase):
     """Sensor showing the current input source."""
 
-    _attr_icon = "mdi:import"
     _attr_name = "Input"
+
+    # Icons for each raw "Source Select" / current source value.
+    _SOURCE_ICONS = {
+        "Raumfeld": "mdi:cast-audio",
+        "LineIn": "mdi:audio-input-rca",
+        "OpticalIn": "mdi:toslink",
+        "TV_ARC": "mdi:hdmi-port",
+        "Spotify": "mdi:spotify",
+        "Radio": "mdi:radio",
+    }
+    _DEFAULT_ICON = "mdi:import"
 
     def __init__(self, client: RaumfeldApiClient, room_data: dict[str, Any]) -> None:
         """Initialize."""
@@ -163,3 +173,4 @@ class RaumfeldInputSensor(RaumfeldSensorBase):
         self._attr_native_value = _SOURCE_RAW_TO_DISPLAY.get(
             current_source, current_source
         )
+        self._attr_icon = self._SOURCE_ICONS.get(current_source, self._DEFAULT_ICON)


### PR DESCRIPTION
## Summary
- Media player: when there's no album art (Line-in, Optical, TV inputs), show an icon and the source name instead of a blank player: `mdi:audio-input-rca` (Line-in), `mdi:toslink` (Optical), `mdi:hdmi-port` (TV).
- "Input" sensor: add a dynamic icon matching the current source — `mdi:cast-audio` (Streaming), `mdi:audio-input-rca` (Line-in), `mdi:toslink` (Optical), `mdi:hdmi-port` (TV), `mdi:spotify` (Spotify), `mdi:radio` (Radio).
- Fix "Input" sensor for Soundbars/Sounddecks (devices with "Source Select"): "Source Select" only distinguishes physical inputs from "Raumfeld" (streaming), so Spotify Connect playback always showed as "Streaming". Now the playback URI is also inspected while streaming, so Spotify Connect/Radio are correctly detected.

## Test plan
- [ ] Switch a room to Line-in/Optical/TV — media player shows the matching icon and source name.
- [ ] Check the "Input" sensor — icon matches the current source (Streaming/Line-in/Optical/TV/Spotify/Radio).
- [ ] On a soundbar/sounddeck, start Spotify Connect playback — Input sensor shows "Spotify" with `mdi:spotify` instead of "Streaming".